### PR TITLE
Lower Swift Version to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
As mentioned in #3, the requirement of Swift 6.1 seems arbitrary and completely unnecessary. It also prevents the usage of SwiftGlass on Xcode 16.2 and below due to it missing from the toolchain.