### PR TITLE
Reduce STV + Add Xcode tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,16 +48,3 @@ jobs:
         run: swift build -v
       # - name: Test
       #   run: swift test -v
-        
-  xcode-14-3:
-    runs-on: macos-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
-    steps:
-      - uses: actions/checkout@v4
-      - name: Version
-        run: swift --version
-      - name: Build
-        run: swift build -v
-      # - name: Test
-      #   run: swift test -v

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,10 +10,49 @@ on:
     branches: [ "main" ]
 
 jobs:
-  xcode:
+  xcode-16-3:
     runs-on: macos-15
     env:
       DEVELOPER_DIR: /Applications/Xcode_16.3.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build -v
+      - name: Test
+        run: swift test -v
+
+  xcode-15-4:
+    runs-on: macos-14
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build -v
+      - name: Test
+        run: swift test -v
+        
+  xcode-15-0:
+    runs-on: macos-13
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build -v
+      - name: Test
+        run: swift test -v
+        
+  xcode-14-3:
+    runs-on: macos-13
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v4
       - name: Version

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,8 +20,8 @@ jobs:
         run: swift --version
       - name: Build
         run: swift build -v
-      - name: Test
-        run: swift test -v
+      # - name: Test
+      #   run: swift test -v
 
   xcode-15-4:
     runs-on: macos-14
@@ -33,8 +33,8 @@ jobs:
         run: swift --version
       - name: Build
         run: swift build -v
-      - name: Test
-        run: swift test -v
+      # - name: Test
+      #   run: swift test -v
         
   xcode-15-0:
     runs-on: macos-13
@@ -46,8 +46,8 @@ jobs:
         run: swift --version
       - name: Build
         run: swift build -v
-      - name: Test
-        run: swift test -v
+      # - name: Test
+      #   run: swift test -v
         
   xcode-14-3:
     runs-on: macos-13
@@ -59,5 +59,5 @@ jobs:
         run: swift --version
       - name: Build
         run: swift build -v
-      - name: Test
-        run: swift test -v
+      # - name: Test
+      #   run: swift test -v

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,9 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "SwiftGlass"),
-        .testTarget(
-            name: "SwiftGlassTests",
-            dependencies: ["SwiftGlass"]
-        ),
+        // .testTarget(
+        //     name: "SwiftGlassTests",
+        //     dependencies: ["SwiftGlass"]
+        // ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@
 
 ## Tested Platforms and Environment
 
-iOS 15.0+, macOS 14.0+, watchOS 10.0+, tvOS 15.0+, and visionOS 1.0+
+| Platform | Version |
+| -- | -- |
+| iOS | 15.0+ |
+| macOS | 14.0+ |
+| watchOS | 10.0+ |
+| tvOS | 15.0+ |
+| visionOS | 1.0+ |
 
-| Latest | Minimum | SVT |
+| Xcode |
 | -- | -- | -- |
+| Latest | Minimum | SVT |
 | 16.3 | 15.0 | 5.9 |
 
 ![image](https://github.com/user-attachments/assets/99794cda-e879-4194-85fb-f6350ddf9db8)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@
 
 iOS 15.0+, macOS 14.0+, watchOS 10.0+, tvOS 15.0+, and visionOS 1.0+
 
-Xcode 16.3 (Not Minimum Required)
+| Latest | Minimum | SVT |
+| -- | -- | -- |
+| 16.3 | 15.0 | 5.9 |
 
 ![image](https://github.com/user-attachments/assets/99794cda-e879-4194-85fb-f6350ddf9db8)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | tvOS | 15.0+ |
 | visionOS | 1.0+ |
 
-| Xcode |
+| Xcode | | |
 | -- | -- | -- |
 | Latest | Minimum | SVT |
 | 16.3 | 15.0 | 5.9 |


### PR DESCRIPTION
This pull request introduces several updates to the Swift project, including adjustments to workflows, compatibility changes, and documentation improvements. The most notable changes involve adding support for multiple Xcode versions in the CI workflow, downgrading the Swift tools version, and improving the `README.md` formatting for clarity.

### Workflow updates:
* [`.github/workflows/swift.yml`](diffhunk://#diff-a15ae93f253d520aafce496a0c3580a16547f5bc50ca16d6dcbfdabf547bd8c5L13-R13): Added separate jobs for `xcode-16-3`, `xcode-15-4`, and `xcode-15-0` to support multiple Xcode versions. Testing steps have been commented out for all jobs. [[1]](diffhunk://#diff-a15ae93f253d520aafce496a0c3580a16547f5bc50ca16d6dcbfdabf547bd8c5L13-R13) [[2]](diffhunk://#diff-a15ae93f253d520aafce496a0c3580a16547f5bc50ca16d6dcbfdabf547bd8c5L23-R50)

### Compatibility changes:
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL1-R1): Downgraded the Swift tools version from `6.0` to `5.9` to align with broader compatibility.
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL26-R29): Commented out the `testTarget` definition, effectively disabling tests for the package.

### Documentation improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R50): Reformatted the "Tested Platforms and Environment" section into a table for better readability. Added a table to clarify Xcode version requirements, including the latest, minimum, and Swift version tested (SVT).