### PR TITLE
Fix crashing on older Xcode

### DIFF
--- a/Demo/Demo/Samples/Essential/Basic.swift
+++ b/Demo/Demo/Samples/Essential/Basic.swift
@@ -46,7 +46,7 @@ struct Basic: View {
                     Text("HOME")
                         .font(.largeTitle)
                         .fontWeight(.heavy)
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(.white)
                 }
                 
 #if !os(watchOS)

--- a/Demo/Demo/Samples/Essential/Input.swift
+++ b/Demo/Demo/Samples/Essential/Input.swift
@@ -20,7 +20,7 @@ struct Input: View {
             .textFieldStyle(.plain)
             .padding(25)
             .glass(
-                color: focus ? .accentColor : .primary,
+                color: focus ? .accentColor : .white,
                 shadowColor: focus ? .accentColor : .primary
             )
             .padding(50)

--- a/Sources/SwiftGlass/SwiftGlass.swift
+++ b/Sources/SwiftGlass/SwiftGlass.swift
@@ -40,17 +40,7 @@ public extension View {
     func glass(
         displayMode: GlassBackgroundModifier.GlassBackgroundDisplayMode = .always,
         radius: CGFloat = 32,
-        color: Color = {
-            #if os(iOS) || os(tvOS)
-            return Color(UIColor.systemBackground)
-            #elseif os(watchOS)
-            return Color(UIColor.black)
-            #elseif os(macOS)
-            return Color(NSColor.controlBackgroundColor)
-            #else
-            return Color.primary
-            #endif
-        }(),
+        color: Color = .white,
         colorOpacity: Double = 0.1,
         material: Material = .ultraThinMaterial,
         gradientOpacity: Double = 0.5,


### PR DESCRIPTION
This pull request introduces several changes to the `SwiftGlass` library and its demo application, focusing on improving visual consistency and compatibility with newer SwiftUI APIs. The most significant updates include modifying default color values, enhancing the `GlassBackgroundModifier` for newer Swift versions, and simplifying fallback implementations for older versions.

### Visual consistency updates:

* [`Demo/Demo/Samples/Essential/Basic.swift`](diffhunk://#diff-5fd55f880fa77b3c2ea0bb5798884002d4e520cc2abdcc0f236c6d5dccfa6f4cL49-R49): Changed the `foregroundStyle` of the "HOME" text from `.primary` to `.white` for better visual consistency.
* [`Demo/Demo/Samples/Essential/Input.swift`](diffhunk://#diff-47137c9099d7759b4cd714bb386fdc283ae321241b3f81f8cfb67feb4a47ff2fL23-R23): Updated the `glass` modifier to use `.white` instead of `.primary` for the background color when not focused.

### Compatibility improvements for `SwiftGlass`:

* [`Sources/SwiftGlass/GlassBackgroundModifier.swift`](diffhunk://#diff-706219eecca13c3bd0ac6a2ba6c3fb00827aa17f87514efe3ac1c52344396902R79-R123): Enhanced the `GlassBackgroundModifier` to leverage new glass effect APIs available in Swift 6.0 and newer platforms, while maintaining fallback implementations for older versions. Added support for `visionOS` and improved gradient stroke rendering. [[1]](diffhunk://#diff-706219eecca13c3bd0ac6a2ba6c3fb00827aa17f87514efe3ac1c52344396902R79-R123) [[2]](diffhunk://#diff-706219eecca13c3bd0ac6a2ba6c3fb00827aa17f87514efe3ac1c52344396902L111-R142)
* [`Sources/SwiftGlass/SwiftGlass.swift`](diffhunk://#diff-30e7fe38b75df1d75b929c4a23902b02f9021c320712712cd1f0f433951af25aL43-R43): Simplified the default `color` parameter in the `glass` modifier to `.white`, removing platform-specific conditional logic.